### PR TITLE
fix: allow connecting to network scanner

### DIFF
--- a/org.kde.skanlite.json
+++ b/org.kde.skanlite.json
@@ -15,7 +15,7 @@
         "--device=all",
         "--share=ipc",
         "--share=network",
-        "--socket=system-bus",
+        "--system-talk-name=org.freedesktop.Avahi",
         "--socket=wayland",
         "--socket=fallback-x11"
     ],

--- a/org.kde.skanlite.json
+++ b/org.kde.skanlite.json
@@ -14,6 +14,8 @@
     "finish-args": [
         "--device=all",
         "--share=ipc",
+        "--share=network",
+        "--socket=system-bus",
         "--socket=wayland",
         "--socket=fallback-x11"
     ],


### PR DESCRIPTION
Without these options, I'm unable to connect to network scanner. Now I can.

Scanning still fails, though.