### PR TITLE
Add sane-airscan backend

### DIFF
--- a/org.kde.skanlite.json
+++ b/org.kde.skanlite.json
@@ -80,6 +80,23 @@
             ]
         },
         {
+            "name": "sane-airscan",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/alexpevzner/sane-airscan/archive/refs/tags/0.99.27.tar.gz",
+                    "sha256": "0d84ca10f9e80d8f5f6bc0f30911660667b6d5b9df8d3fd45be0dcc29775aa84",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 121086,
+                        "stable-only": true,
+                        "url-template": "https://github.com/alexpevzner/sane-airscan/archive/refs/tags/$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
             "name": "skanlite",
             "buildsystem": "cmake-ninja",
             "post-install": [


### PR DESCRIPTION
This adds support for a few more network scanners, and for connecting to AirSane,
which allows publishing local scanners over the network.
